### PR TITLE
Use of JSON.stringify instead of JSON-like string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
-var gutil = require('gulp-util');
-var exec = require('child_process').exec;
-var es = require('event-stream');
-var os = require('os');
+var exec = require('child_process').exec,
+  es = require('event-stream'),
+  os = require('os');
 
 module.exports = function(cb) {
   var commands = {
@@ -20,7 +19,7 @@ module.exports = function(cb) {
     var git_cmd = "echo " + cmd + " && git " + command.join(" ");
     var child = exec(git_cmd, function(err, stdout, stderr) {});
     streams.push(child.stdout.pipe(es.wait()));
-  })
+  });
   var stream = es.merge.apply(es, streams);
   return stream
     .pipe(es.map(function(data, cb) {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   },
   "author": "Kevin King kingpkevin@gmail.com",
   "main": "./index.js",
-  "dependencies": {
-    "gulp-util": "~2.2.14"
-  },
+  "dependencies": {},
   "devDependencies": {
     "mocha": "*",
     "should": "*",


### PR DESCRIPTION
Script refactored to use JSON.stringify instead of manually constructed
JSON.

Fixes problems with end of lines in Windows (so works fine now in
Mac/Linux and Windows).
